### PR TITLE
Handle GYP_GENERATORS="ninja,xcode" case

### DIFF
--- a/cr
+++ b/cr
@@ -136,7 +136,7 @@ do_build() {
   if [ -n "$BUILD_THREADS_CUSTOM" ]; then
     BUILD_THREADS="$BUILD_THREADS_CUSTOM"
   fi
-  if [ "$GYP_GENERATORS" == "ninja" ]; then
+  if [[ "$GYP_GENERATORS" == *"ninja"* ]]; then
     mkdir -p "out/$BUILD_TYPE" > /dev/null 2>&1
     ninja -C "out/$BUILD_TYPE" $TARGET"" -j"$BUILD_THREADS"
   else


### PR DESCRIPTION
If GYP_GENERATORS contains 'ninja' it should be enough to run ninja ant not fallback to make.

I'd say that you might want to update first configuration of ninja as well.
