### PR TITLE
Warn the user that the dev_tools installation directory is not owned by the current user

### DIFF
--- a/cr
+++ b/cr
@@ -175,6 +175,9 @@ do_devtools() {
     cat "$GYP_FILE"
   else
     mkdir -p "$GYP_FILE" && rmdir "$GYP_FILE"
+    if [ $(stat -c "%U %G" "$GYP_FILE") -ne "$(id -n -u) $(id -n -g)"]; then
+        echo "WARNING: $GYP_FILE is not owned by the current user!"
+    fi
     echo "{
   'variables': {
     'debug_devtools': 1

--- a/cr
+++ b/cr
@@ -175,7 +175,7 @@ do_devtools() {
     cat "$GYP_FILE"
   else
     mkdir -p "$GYP_FILE" && rmdir "$GYP_FILE"
-    if [ $(stat -c "%U %G" "$GYP_FILE") -ne "$(id -n -u) $(id -n -g)"]; then
+    if [ $(stat -c "%U" "$GYP_FILE") -ne "$(id -n -u)"]; then
         echo "WARNING: $GYP_FILE is not owned by the current user!"
     fi
     echo "{


### PR DESCRIPTION
I installed dev_tools to /opt/dev_tools, and found that it wasn't working. I later discovered that it uses Git to update dev_tools, and thus required write access from the current user. To fix this, I changed the ownership of /opt/dev_tools to be for my user, but I thought cr should warn the user if the directory is not owned in the first place. It may not be perfect, and there is probably a better solution, but this is a good option for now in my opinion :)
